### PR TITLE
Fix console error about RichText children element keys

### DIFF
--- a/play-media/src/components/RichText/RichText.tsx
+++ b/play-media/src/components/RichText/RichText.tsx
@@ -24,39 +24,39 @@ export const RichText: FC<Props> = ({ body, className }) => {
   );
   const componentMap = useMemo(
     () => ({
-      heading: (context: any, children: any) => {
-        return <Heading level={context.attrs.level}>{children}</Heading>;
+      heading: (context: any, children: any, key: string) => {
+        return <Heading level={context.attrs.level} key={key}>{children}</Heading>;
       },
-      paragraph: (context: any, children: any) => {
-        return <Paragraph>{children}</Paragraph>;
+      paragraph: (context: any, children: any, key: string) => {
+        return <Paragraph key={key}>{children}</Paragraph>;
       },
-      bulletList: (context: any, children: any) => {
-        return <BulletList>{children}</BulletList>;
+      bulletList: (context: any, children: any, key: string) => {
+        return <BulletList key={key}>{children}</BulletList>;
       },
-      listItem: (context: any, children: any) => {
-        return <ListItem>{children}</ListItem>;
+      listItem: (context: any, children: any, key: string) => {
+        return <ListItem key={key}>{children}</ListItem>;
       },
-      orderedList: (context: any, children: any) => {
-        return <OrderedList>{children}</OrderedList>;
+      orderedList: (context: any, children: any, key: string) => {
+        return <OrderedList key={key}>{children}</OrderedList>;
       },
-      codeBlock: (context: any, children: any) => {
-        return <CodeBlock>{children}</CodeBlock>;
+      codeBlock: (context: any, children: any, key: string) => {
+        return <CodeBlock key={key}>{children}</CodeBlock>;
       },
-      blockquote: (context: any, children: any) => {
-        return <BlockQuote>{children}</BlockQuote>;
+      blockquote: (context: any, children: any, key: string) => {
+        return <BlockQuote key={key}>{children}</BlockQuote>;
       },
-      text: (context: any) => {
+      text: (context: any, key: string) => {
         const hasMarks = !!context?.marks?.length;
 
         if (!hasMarks) {
-          return <Text>{context.text}</Text>;
+          return <Text key={key}>{context.text}</Text>;
         }
 
         const linkMark = context.marks.find((mark: any) => mark.type === 'link');
 
         if (linkMark) {
           return (
-            <RichTextLink href={linkMark.attrs.href} target={linkMark.attrs.target}>
+            <RichTextLink href={linkMark.attrs.href} target={linkMark.attrs.target} key={key}>
               {context.text}
             </RichTextLink>
           );
@@ -65,10 +65,10 @@ export const RichText: FC<Props> = ({ body, className }) => {
         const codeMark = context.marks.find((mark: any) => mark.type === 'code');
 
         if (codeMark) {
-          return <CodeText>{context.text}</CodeText>;
+          return <CodeText key={key}>{context.text}</CodeText>;
         }
 
-        return <Text marks={context.marks}>{context.text}</Text>;
+        return <Text marks={context.marks} key={key}>{context.text}</Text>;
       },
     }),
     []

--- a/play-media/src/components/RichText/utilities.ts
+++ b/play-media/src/components/RichText/utilities.ts
@@ -3,18 +3,22 @@ import { RichTextResponseItem } from './types/response';
 
 const getComponentFromChild = (
   child: any,
-  componentMap: Record<string, FunctionComponent>
+  componentMap: Record<string, FunctionComponent>,
+  ...indexes: number[]
 ): ReactNode => {
+  const key = indexes.join('_');
+
   if (child?.content?.length) {
     return componentMap[child.type](
       child,
-      child.content.map((childContext: any) => getComponentFromChild(childContext, componentMap))
+      child.content.map((childContext: any, childIndex: number) => getComponentFromChild(childContext, componentMap, ...indexes, childIndex)),
+      key
     );
   }
 
-  return componentMap[child.type](child);
+  return componentMap[child.type](child, key);
 };
 
 export const getComponentTree = (content: any, componentMap: any) => {
-  return content.map((element: any) => getComponentFromChild(element, componentMap));
+  return content.map((element: any, index: number) => getComponentFromChild(element, componentMap, index));
 };


### PR DESCRIPTION
This error was popping in the dev server and browser console on event pages:
```
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <Paragraph>. See https://reactjs.org/link/warning-keys for more information.
    at Text (webpack-internal:///./components/RichText/components/Text.tsx:14:17)
    at RichText (webpack-internal:///./components/RichText/RichText.tsx:36:21)
    at div
    at main
    at EventDetail (webpack-internal:///./pages/event/[slug].tsx:25:24)
    at App (webpack-internal:///./pages/_app.tsx:13:16)
    at StyleRegistry (C:\projects\Sitecore.Demo.CHONE\play-media\src\node_modules\styled-jsx\dist\index\index.js:449:36)
    at PathnameContextProviderAdapter (C:\projects\Sitecore.Demo.CHONE\play-media\src\node_modules\next\dist\shared\lib\router\adapters.js:60:11)
    at AppContainer (C:\projects\Sitecore.Demo.CHONE\play-media\src\node_modules\next\dist\server\render.js:289:29)
    at AppContainerWithIsomorphicFiberStructure (C:\projects\Sitecore.Demo.CHONE\play-media\src\node_modules\next\dist\server\render.js:325:57)
    at div
    at Body (C:\projects\Sitecore.Demo.CHONE\play-media\src\node_modules\next\dist\server\render.js:612:21)
```

A similar one for the Paragraph component was also displayed.